### PR TITLE
Attachments upload with 429

### DIFF
--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -51,7 +51,6 @@ doors_creator = make_assets_create(attachment_creator=attachment_create, confirm
 
 
 def create_rkvst_paris(doors):
-
     # Unlike the others, which feature images of the whole building,
     # this one is actually a close-up of the connected door terminal
     return doors_creator(
@@ -85,7 +84,6 @@ def create_rkvst_paris(doors):
 
 
 def create_cityhall(doors):
-
     return doors_creator(
         doors,
         "City Hall front door",
@@ -148,7 +146,6 @@ def create_courts(doors):
 
 
 def create_bastille(doors):
-
     return doors_creator(
         doors,
         "Bastille front door",
@@ -182,7 +179,6 @@ def create_bastille(doors):
 
 
 def create_gdn_front(doors):
-
     return doors_creator(
         doors,
         "Gare du Nord apartments front door",
@@ -216,7 +212,6 @@ def create_gdn_front(doors):
 
 
 def create_gdn_side(doors):
-
     return doors_creator(
         doors,
         "Gare du Nord apartments side door",
@@ -577,7 +572,6 @@ def open_door(doors, doorid, cards, cardid):
 
 
 def run(arch, args):
-
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Fetching use case test assets namespace %s", args.namespace)
 

--- a/archivist_samples/signed_records/main.py
+++ b/archivist_samples/signed_records/main.py
@@ -308,7 +308,6 @@ def print_history(archivist, asset_name):
 # Main app loop
 ###############
 def run(arch, args):
-
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     if args.namespace:
         asset_name = "-".join(["signed-records", args.namespace])

--- a/archivist_samples/software_bill_of_materials/run.py
+++ b/archivist_samples/software_bill_of_materials/run.py
@@ -13,7 +13,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 def run(arch, args):
-
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Fetching use case test assets namespace %s", args.namespace)
 

--- a/archivist_samples/software_bill_of_materials/software_deployment.py
+++ b/archivist_samples/software_bill_of_materials/software_deployment.py
@@ -48,7 +48,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         if sbom_environment is not None:
             self._environment = sbom_environment
         else:
@@ -79,7 +78,6 @@ class SoftwareDeployment:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         if sbom_installation["environment"] is not None:
             self._environment = sbom_installation["environment"]
         else:
@@ -143,7 +141,6 @@ class SoftwareDeployment:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         if sbom_decomission["environment"] is not None:
             self._environment = sbom_decomission["environment"]
         else:
@@ -201,7 +198,6 @@ class SoftwareDeployment:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         if sbom_upgrade["environment"] is not None:
             self._environment = sbom_upgrade["environment"]
         else:
@@ -263,7 +259,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         if sbom_planned["environment"] is not None:
             self._environment = sbom_planned["environment"]
         else:
@@ -309,7 +304,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         if sbom_accepted["environment"] is not None:
             self._environment = sbom_accepted["environment"]
         else:
@@ -357,7 +351,6 @@ class SoftwareDeployment:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         if sbom_rollback["environment"] is not None:
             self._environment = sbom_rollback["environment"]
         else:
@@ -419,7 +412,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         if sbom_planned["environment"] is not None:
             self._environment = sbom_planned["environment"]
         else:
@@ -465,7 +457,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         if sbom_accepted["environment"] is not None:
             self._environment = sbom_accepted["environment"]
         else:
@@ -513,7 +504,6 @@ class SoftwareDeployment:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         self._add_attachments(attachments)
 
         props = {

--- a/archivist_samples/software_bill_of_materials/software_package.py
+++ b/archivist_samples/software_bill_of_materials/software_package.py
@@ -65,7 +65,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         attrs = {
             "arc_description": sbom_description,
             "arc_display_type": "Software Package",
@@ -112,7 +111,6 @@ class SoftwarePackage:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         # sbom_name: str,
         # sbom_description: str,
         # sbom_hash: str,
@@ -174,7 +172,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -207,7 +204,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -242,7 +238,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -276,7 +271,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -312,7 +306,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict],
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -348,7 +341,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -386,7 +378,6 @@ class SoftwarePackage:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",

--- a/archivist_samples/synsation/simulator.py
+++ b/archivist_samples/synsation/simulator.py
@@ -47,7 +47,12 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
         input("Press to enact White Hat Hacker")
 
     cve_id = "CVE2020-deadbeef"
-    MyAsset(ac, asset_id, tw, "Brian@WhiteHatHackers.io",).report_vulnerability(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "Brian@WhiteHatHackers.io",
+    ).report_vulnerability(
         (
             f"Synsation Industries {asset_type}s are vulnerable "
             f"to {cve_id}. Upgrade as soon as possible."
@@ -63,7 +68,12 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     else:
         input("Press to enact OEM issue patch")
 
-    MyAsset(ac, asset_id, tw, "Releases@SynsationIndustries.com",).patch_vulnerability(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "Releases@SynsationIndustries.com",
+    ).patch_vulnerability(
         f"Patch for critical vulnerability '{cve_id}' released in version 1.6",
         (
             "SHA256-sum for official 1.6 release: "
@@ -84,7 +94,12 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
         ac, "trafficlightconformance.pdf", "application/pdf"
     )
 
-    MyAsset(ac, asset_id, tw, "Releases@SynsationIndustries.com",).certify_patch(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "Releases@SynsationIndustries.com",
+    ).certify_patch(
         "Safety conformance approved for version 1.6. See attached conformance report",
         "DVA Conformance Report attached",
         {
@@ -112,7 +127,12 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     else:
         input("Press to enact Owner approves")
 
-    MyAsset(ac, asset_id, tw, "Legal@SmartCity.fr",).service_required(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "Legal@SmartCity.fr",
+    ).service_required(
         "Version 1.6 accepted. Please install ASAP",
         job_corval,
     )
@@ -124,12 +144,22 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
     else:
         input("Press to enact Maintenance")
 
-    MyAsset(ac, asset_id, tw, "Phil@SynsationServicing.com",).service(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "Phil@SynsationServicing.com",
+    ).service(
         f"Upgraded and restarted {asset_type} during safe downtime window",
         job_corval,
     )
 
-    MyAsset(ac, asset_id, tw, "otaService@SynsationServicing.com",).update_firmware(
+    MyAsset(
+        ac,
+        asset_id,
+        tw,
+        "otaService@SynsationServicing.com",
+    ).update_firmware(
         "Responding to vulnerability 'CVE2020-deadbeef' with patch 'v1.6'",
         "1.6",
         cve_corval,

--- a/archivist_samples/testing/archivist_parser.py
+++ b/archivist_samples/testing/archivist_parser.py
@@ -97,7 +97,6 @@ def common_parser(description):
 
 
 def endpoint(args):
-
     if args.verbose:
         set_logger("DEBUG")
     else:
@@ -115,7 +114,7 @@ def endpoint(args):
         with open(args.auth_token_file, mode="r", encoding="utf-8") as tokenfile:
             authtoken = tokenfile.read().strip()
 
-        arch = Archivist(args.url, authtoken, verify=False, fixtures=fixtures)
+        arch = Archivist(args.url, authtoken, fixtures=fixtures)
 
     if arch is None:
         LOGGER.error("Critical error.  Aborting.")

--- a/archivist_samples/wipp/run.py
+++ b/archivist_samples/wipp/run.py
@@ -14,7 +14,6 @@ LOGGER = logging.getLogger(__name__)
 
 
 def run(arch, args):
-
     LOGGER.info("Using version %s of rkvst-archivist", about.__version__)
     LOGGER.info("Fetching use case test assets namespace %s", args.namespace)
 

--- a/archivist_samples/wipp/wipp.py
+++ b/archivist_samples/wipp/wipp.py
@@ -93,7 +93,6 @@ class Wipp:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         attrs = {
             "arc_description": description,
             "arc_serial_number": serial,
@@ -140,7 +139,6 @@ class Wipp:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -183,7 +181,6 @@ class Wipp:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -227,7 +224,6 @@ class Wipp:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -267,7 +263,6 @@ class Wipp:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -300,7 +295,6 @@ class Wipp:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -333,7 +327,6 @@ class Wipp:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -368,7 +361,6 @@ class Wipp:
         attachments: Optional[list] = None,
         custom_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -402,7 +394,6 @@ class Wipp:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",
@@ -442,7 +433,6 @@ class Wipp:
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
     ):
-
         props = {
             "operation": "Record",
             "behaviour": "RecordEvidence",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
 -r requirements.txt
 
 # code quality
-autopep8~=1.6
-black~=22.6
-pycodestyle~=2.9
-pylint~=2.14
+autopep8~=2.0
+black~=23.1
+pycodestyle~=2.10
+pylint~=2.16
 
 # uploading to pypi
-build~=0.8
+build~=0.10
 twine~=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography~=38.0
-rkvst-archivist==0.20.0
-pyyaml~=5.4
+rkvst-archivist==0.20.2
+pyyaml~=6.0


### PR DESCRIPTION
Problem:
If an attachments upload encounters a 429 then the connection is closed resulting in a zero length file.

Solution:
Make sure that Verify is True which will enable keep-alive. Additionally upgrade all dependencies and reformat code to latest standard.