### PR TITLE
Fix attachment attribute naming

### DIFF
--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -16,7 +16,7 @@ from archivist.errors import ArchivistNotFoundError
 from .images import assets as images_assets
 from .images import events as images_events
 
-from ..testing.assets import make_assets_create
+from ..testing.assets import make_assets_create, AttachmentDescription
 
 
 DOOR_TERMINAL = "Door access terminal"
@@ -29,15 +29,15 @@ LOGGER = logging.getLogger(__name__)
 ############
 
 
-def attachment_create(doors, name):
-    with resources.open_binary(images_assets, name) as fd:
+def attachment_create(doors, attachment_description: AttachmentDescription):
+    with resources.open_binary(images_assets, attachment_description.filename) as fd:
         attachment = doors.attachments.upload(fd)
         result = {
             "arc_attribute_type": "arc_attachment",
             "arc_blob_identity": attachment["identity"],
             "arc_blob_hash_alg": attachment["hash"]["alg"],
             "arc_blob_hash_value": attachment["hash"]["value"],
-            "arc_file_name": name,
+            "arc_file_name": attachment_description.filename,
         }
 
         return result
@@ -78,7 +78,7 @@ def create_rkvst_paris(doors):
             },
         },
         attachments=[
-            "entry_terminal.jpg",
+            AttachmentDescription("entry_terminal.jpg", "arc_primary_image"),
         ],
     )
 
@@ -109,7 +109,7 @@ def create_cityhall(doors):
             },
         },
         attachments=[
-            "cityhall.jpg",
+            AttachmentDescription("cityhall.jpg", "arc_primary_image"),
         ],
     )
 
@@ -140,7 +140,7 @@ def create_courts(doors):
             },
         },
         attachments=[
-            "courts.jpg",
+            AttachmentDescription("courts.jpg", "arc_primary_image"),
         ],
     )
 
@@ -173,7 +173,7 @@ def create_bastille(doors):
             },
         },
         attachments=[
-            "bastille.jpg",
+            AttachmentDescription("bastille.jpg", "arc_primary_image"),
         ],
     )
 
@@ -206,7 +206,7 @@ def create_gdn_front(doors):
             },
         },
         attachments=[
-            "gdn_front.jpg",
+            AttachmentDescription("gdn_front.jpg", "arc_primary_image"),
         ],
     )
 
@@ -239,7 +239,7 @@ def create_gdn_side(doors):
             },
         },
         attachments=[
-            "gdn_side.jpg",
+            AttachmentDescription("gdn_side.jpg", "arc_primary_image"),
         ],
     )
 

--- a/archivist_samples/software_bill_of_materials/run.py
+++ b/archivist_samples/software_bill_of_materials/run.py
@@ -8,6 +8,7 @@ from sys import exit as sys_exit
 from archivist import about
 
 from .software_package import SoftwarePackage
+from ..testing.assets import AttachmentDescription
 
 LOGGER = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ def run(arch, args):
             "sbom_license": "www.gnu.org/licenses/gpl.txt",
             "proprietary_secret": "For your eyes only",
         },
-        attachments=[("Comp_2.jpeg", "arc_primary_image")],
+        attachments=[AttachmentDescription("Comp_2.jpeg", "arc_primary_image")],
     )
     if package.existed:
         LOGGER.info("Software Package already Created: %s", package_name)
@@ -47,7 +48,7 @@ def run(arch, args):
             "supplier": "Coyote Services, Inc.",
             "uuid": "com.acme.rrd2013-ce-sp1-v4-1-5-0",
         },
-        attachments=[("v4_1_5_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v4_1_5_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Release registered.")
 
@@ -62,7 +63,7 @@ def run(arch, args):
             "supplier": "Coyote Services, Inc.",
             "uuid": "com.acme.rrd2013-ce-sp1-v4-1-6-0",
         },
-        attachments=[("v4_1_6_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v4_1_6_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Release registered.")
 
@@ -80,7 +81,7 @@ def run(arch, args):
             "uuid": "com.acme.rrd2013-ce-sp1-v4-1-6-1",
             "reference": "CVE-20210613-1",
         },
-        attachments=[("v4_1_6_1_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v4_1_6_1_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Private patch registered.")
 
@@ -95,7 +96,7 @@ def run(arch, args):
             "supplier": "Coyote Services, Inc.",
             "uuid": "com.acme.rrd2013-ce-sp1-v4-1-7-0",
         },
-        attachments=[("v4_1_7_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v4_1_7_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Release registered.")
 
@@ -110,7 +111,7 @@ def run(arch, args):
             "reference": "BIG_V_5",
             "captain": "Deputy Dawg",
         },
-        attachments=[("v5_0_0_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v5_0_0_sbom.xml", "SWID SBOM")],
     )
 
     LOGGER.info("6 Approve major upgrade...")
@@ -125,7 +126,7 @@ def run(arch, args):
             "captain": "Deputy Dawg",
             "approver": "Yosemite Sam",
         },
-        attachments=[("v5_0_0_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v5_0_0_sbom.xml", "SWID SBOM")],
     )
 
     LOGGER.info("7 Release major upgrade...")
@@ -139,7 +140,7 @@ def run(arch, args):
             "supplier": "Coyote Services, Inc.",
             "uuid": "com.acme.rrd2013-ce-sp1-v5-0-0-0",
         },
-        attachments=[("v5_0_0_sbom.xml", "SWID SBOM")],
+        attachments=[AttachmentDescription("v5_0_0_sbom.xml", "SWID SBOM")],
     )
     LOGGER.info("Release registered.")
     sys_exit(0)

--- a/archivist_samples/software_bill_of_materials/software_package.py
+++ b/archivist_samples/software_bill_of_materials/software_package.py
@@ -8,11 +8,11 @@ from importlib import resources
 
 import logging
 from sys import exit as sys_exit
-from typing import Optional
+from typing import List, Optional
 
 from archivist import archivist as type_helper
 
-from ..testing.assets import make_assets_create
+from ..testing.assets import make_assets_create, AttachmentDescription
 
 from . import sbom_files
 
@@ -20,17 +20,17 @@ from . import sbom_files
 LOGGER = logging.getLogger(__name__)
 
 
-def attachment_create(sboms, name):
-    LOGGER.info("sbom attachment creator: %s", name)
-    with resources.open_binary(sbom_files, name[0]) as fd:
+def attachment_create(sboms, attachment_description: AttachmentDescription):
+    LOGGER.info("sbom attachment creator: %s", attachment_description.filename)
+    with resources.open_binary(sbom_files, attachment_description.filename) as fd:
         attachment = sboms.attachments.upload(fd)
         result = {
             "arc_attribute_type": "arc_attachment",
             "arc_blob_identity": attachment["identity"],
             "arc_blob_hash_alg": attachment["hash"]["alg"],
             "arc_blob_hash_value": attachment["hash"]["value"],
-            "arc_display_name": name[1],
-            "arc_file_name": name[0],
+            "arc_display_name": attachment_description.attribute_name,
+            "arc_file_name": attachment_description.filename,
         }
         return result
 
@@ -62,7 +62,7 @@ class SoftwarePackage:
         sbom_name: str,
         sbom_description: str,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         attrs = {
@@ -106,7 +106,7 @@ class SoftwarePackage:
         self,
         sbom: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         latest_sbom: Optional[dict] = None,
         custom_attrs: Optional[dict] = None,
         custom_asset_attrs: Optional[dict] = None,
@@ -139,8 +139,10 @@ class SoftwarePackage:
             "sbom_uuid": sbom["uuid"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -169,7 +171,7 @@ class SoftwarePackage:
         self,
         sbom_planned: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -187,8 +189,10 @@ class SoftwarePackage:
             "sbom_planned_reference": sbom_planned["reference"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -201,7 +205,7 @@ class SoftwarePackage:
         self,
         sbom_accepted: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -220,8 +224,10 @@ class SoftwarePackage:
             "sbom_accepted_vuln_reference": sbom_accepted["reference"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -235,7 +241,7 @@ class SoftwarePackage:
         self,
         sbom_patch: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -254,8 +260,10 @@ class SoftwarePackage:
             "sbom_patch_uuid": sbom_patch["uuid"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -268,7 +276,7 @@ class SoftwarePackage:
         self,
         sbom_patch: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -288,8 +296,10 @@ class SoftwarePackage:
             "sbom_patch_vuln_reference": sbom_patch["reference"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -303,7 +313,7 @@ class SoftwarePackage:
         self,
         vuln: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict],
     ):
         props = {
@@ -325,8 +335,10 @@ class SoftwarePackage:
             "vuln_target_version": vuln["target_version"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -338,7 +350,7 @@ class SoftwarePackage:
     def vuln_update(
         self,
         vuln: dict,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -360,8 +372,10 @@ class SoftwarePackage:
             "vuln_target_version": vuln["target_version"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -375,7 +389,7 @@ class SoftwarePackage:
         self,
         sbom_eol: dict,
         *,
-        attachments: Optional[list] = None,
+        attachments: Optional[List[AttachmentDescription]] = None,
         custom_attrs: Optional[dict] = None,
     ):
         props = {
@@ -393,8 +407,10 @@ class SoftwarePackage:
             "sbom_eol_target_date": sbom_eol["target_date"],
         }
         if attachments:
-            for i, attachment in enumerate(attachments):
-                attrs[f"attachment_attr_{i}"] = attachment_create(self.arch, attachment)
+            for attachment in attachments:
+                attrs[attachment.attribute_name] = attachment_create(
+                    self.arch, attachment
+                )
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)

--- a/archivist_samples/synsation/simulator.py
+++ b/archivist_samples/synsation/simulator.py
@@ -109,7 +109,7 @@ def demo_flow(ac, asset_id, asset_type, tw, wait):
                 "arc_blob_hash_alg": iattachment["hash"]["alg"],
                 "arc_blob_hash_value": iattachment["hash"]["value"],
             },
-            "attachment_attr_1": {
+            "Conformance Report": {
                 "arc_display_name": "Conformance Report",
                 "arc_attribute_type": "arc_attachment",
                 "arc_blob_identity": rattachment["identity"],

--- a/archivist_samples/synsation/synsation_corporation.py
+++ b/archivist_samples/synsation/synsation_corporation.py
@@ -6,9 +6,7 @@ import logging
 import random
 import time
 
-from ..testing.assets import (
-    make_assets_create,
-)
+from ..testing.assets import make_assets_create, AttachmentDescription
 
 from .util import (
     asset_attachment_upload_from_file,
@@ -18,14 +16,16 @@ from .util import (
 LOGGER = logging.getLogger(__name__)
 
 
-def attachment_create(arch, name):
-    attachment = asset_attachment_upload_from_file(arch, name, "image/jpg")
+def attachment_create(arch, attachment_description: AttachmentDescription):
+    attachment = asset_attachment_upload_from_file(
+        arch, attachment_description.filename, "image/jpg"
+    )
     result = {
         "arc_attribute_type": "arc_attachment",
         "arc_blob_identity": attachment["identity"],
         "arc_blob_hash_alg": attachment["hash"]["alg"],
         "arc_blob_hash_value": attachment["hash"]["value"],
-        "arc_file_name": name,
+        "arc_file_name": attachment_description.filename,
     }
 
     return result
@@ -98,9 +98,9 @@ def create_assets(arch, asset_types, locations, num_assets, timedelay):
                 "arc_display_type": displaytype,
             },
             location=location,
-            attachments={
-                asset_types[displaytype],
-            },
+            attachments=[
+                AttachmentDescription(asset_types[displaytype], "arc_primary_image"),
+            ],
         )
         corporation_assets[displayname] = newasset["identity"]
 

--- a/archivist_samples/synsation/synsation_manufacturing.py
+++ b/archivist_samples/synsation/synsation_manufacturing.py
@@ -6,19 +6,21 @@
 import string
 import random
 
-from ..testing.assets import make_assets_create
+from ..testing.assets import make_assets_create, AttachmentDescription
 
 from .util import asset_attachment_upload_from_file
 
 
-def attachment_create(arch, name):
-    attachment = asset_attachment_upload_from_file(arch, name, "image/jpg")
+def attachment_create(arch, attachment_description: AttachmentDescription):
+    attachment = asset_attachment_upload_from_file(
+        arch, attachment_description.filename, "image/jpg"
+    )
     result = {
         "arc_attribute_type": "arc_attachment",
         "arc_blob_identity": attachment["identity"],
         "arc_blob_hash_alg": attachment["hash"]["alg"],
         "arc_blob_hash_value": attachment["hash"]["value"],
-        "arc_file_name": name,
+        "arc_file_name": attachment_description.filename,
     }
 
     return result
@@ -91,7 +93,7 @@ def create_shipping_crate(
         },
         location=loc_id,
         attachments=[
-            image,
+            AttachmentDescription(image, "arc_primary_image"),
         ],
     )
     return newasset, existed

--- a/archivist_samples/testing/assets.py
+++ b/archivist_samples/testing/assets.py
@@ -3,12 +3,21 @@
 
 # pylint:  disable=missing-docstring
 
+from dataclasses import dataclass
 import logging
+from typing import Callable, Dict, List, Optional
+from archivist import archivist as type_helper
 
 from archivist.errors import ArchivistNotFoundError
 from .locations import locations_create_if_not_exists
 
 LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class AttachmentDescription:
+    filename: str
+    attribute_name: str
 
 
 def assets_create_if_not_exists(arch, attrs, *, confirm=False):
@@ -31,15 +40,18 @@ def assets_create_if_not_exists(arch, attrs, *, confirm=False):
     return arch.assets.create(attrs=attrs, confirm=confirm)
 
 
-def make_assets_create(attachment_creator=None, confirm=False):
+def make_assets_create(
+    attachment_creator: Optional[
+        Callable[[type_helper.Archivist, AttachmentDescription], Dict]
+    ] = None,
+    confirm=False,
+):
     """
     Creates a general function that creates an asset with a location
     and a list of attachments but only if the asset does not already exist.
 
     the argument is the method that creates an attachment of the form
-
-         attachment_create(arch, "filename")
-
+         attachment_create(arch, ("filename", "display_name"))
     """
 
     def assets_create(
@@ -48,7 +60,7 @@ def make_assets_create(attachment_creator=None, confirm=False):
         asset_attrs,
         *,
         location=None,
-        attachments=None,
+        attachments: Optional[List[AttachmentDescription]] = None,
     ):
         asset = None
         existed = False
@@ -71,13 +83,9 @@ def make_assets_create(attachment_creator=None, confirm=False):
                 asset_attrs["arc_home_location_identity"] = location["identity"]
 
             if attachments is not None and attachment_creator is not None:
-                for i, attachment in enumerate(attachments):
+                for attachment in attachments:
                     attachment_attr = attachment_creator(arch, attachment)
-                    if i == 0:
-                        asset_attrs["arc_primary_image"] = attachment_attr
-                        continue
-
-                    asset_attrs[f"attachment_attr_{i}"] = attachment_attr
+                    asset_attrs[attachment.attribute_name] = attachment_attr
 
             LOGGER.debug("asset_attrs %s", asset_attrs)
             asset = arch.assets.create(

--- a/archivist_samples/wipp/run.py
+++ b/archivist_samples/wipp/run.py
@@ -9,6 +9,7 @@ from sys import exit as sys_exit
 from archivist import about
 
 from .wipp import Wipp, upload_attachment
+from ..testing.assets import AttachmentDescription
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ def run(arch, args):
         drumname,
         "Standard non-POC 55 gallon drum",
         args.namespace,
-        attachments=[("55gallon.jpg", "arc_primary_image")],
+        attachments=[AttachmentDescription("55gallon.jpg", "arc_primary_image")],
         custom_attrs={
             "wipp_capacity": "55",
             "wipp_package_id": args.namespace,
@@ -47,7 +48,7 @@ def run(arch, args):
         caskname,
         "NRC certified type-B road shipping container, capacity 3 x 55-gallon drum",
         args.namespace,
-        attachments=[("rh72b.png", "arc_primary_image")],
+        attachments=[AttachmentDescription("rh72b.png", "arc_primary_image")],
         custom_attrs={
             "wipp_capacity": "3",
         },
@@ -70,9 +71,17 @@ def run(arch, args):
         },
         attachments=[
             upload_attachment(
-                arch, "DOE-WIPP-02-3122_Rev_9_FINAL.pdf", "Reference WAC"
+                arch,
+                AttachmentDescription(
+                    "DOE-WIPP-02-3122_Rev_9_FINAL.pdf", "Reference WAC"
+                ),
             ),
-            upload_attachment(arch, "characterization.pdf", "Characterization report"),
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "characterization.pdf", "Characterization report"
+                ),
+            ),
         ],
     )
     LOGGER.info("Characterization registered...")
@@ -88,9 +97,14 @@ def run(arch, args):
             "total_confirmed": "2.12E+02",
         },
         attachments=[
-            upload_attachment(arch, "wipp_radiography.jpg", "arc_primary_image"),
             upload_attachment(
-                arch, "DOE-WIPP-02-3122_Rev_9_FINAL.pdf", "Reference WAC"
+                arch, AttachmentDescription("wipp_radiography.jpg", "arc_primary_image")
+            ),
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "DOE-WIPP-02-3122_Rev_9_FINAL.pdf", "Reference WAC"
+                ),
             ),
         ],
     )
@@ -105,7 +119,9 @@ def run(arch, args):
             "container": cask.asset["identity"],
         },
         attachments=[
-            upload_attachment(arch, "trupact_loading.jpg", "arc_primary_image")
+            upload_attachment(
+                arch, AttachmentDescription("trupact_loading.jpg", "arc_primary_image")
+            )
         ],
     )
     cask.loading(
@@ -118,7 +134,9 @@ def run(arch, args):
             "wipp_inventory": drum.asset["identity"],
         },
         attachments=[
-            upload_attachment(arch, "trupact_loading.jpg", "arc_primary_image")
+            upload_attachment(
+                arch, AttachmentDescription("trupact_loading.jpg", "arc_primary_image")
+            )
         ],
     )
     LOGGER.info("Loading registered...")
@@ -131,7 +149,12 @@ def run(arch, args):
             + cask.asset["attributes"]["arc_display_name"],
         },
         attachments=[
-            upload_attachment(arch, "preshipment_inspection.jpg", "arc_primary_image")
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "preshipment_inspection.jpg", "arc_primary_image"
+                ),
+            )
         ],
     )
     cask.preshipping(
@@ -139,7 +162,12 @@ def run(arch, args):
             "description": "Inspected " + cask.asset["attributes"]["arc_display_name"],
         },
         attachments=[
-            upload_attachment(arch, "preshipment_inspection.jpg", "arc_primary_image")
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "preshipment_inspection.jpg", "arc_primary_image"
+                ),
+            )
         ],
     )
     LOGGER.info("Pre-shipping inspection registered...")
@@ -152,9 +180,14 @@ def run(arch, args):
             + cask.asset["attributes"]["arc_display_name"],
         },
         attachments=[
-            upload_attachment(arch, "truck_departure.jpg", "arc_primary_image"),
             upload_attachment(
-                arch, "SRS_to_WPP_route_instructions.pdf", "approved_route"
+                arch, AttachmentDescription("truck_departure.jpg", "arc_primary_image")
+            ),
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "SRS_to_WPP_route_instructions.pdf", "approved_route"
+                ),
             ),
         ],
     )
@@ -164,9 +197,14 @@ def run(arch, args):
             + "departing for WIPP."
         },
         attachments=[
-            upload_attachment(arch, "truck_departure.jpg", "arc_primary_image"),
             upload_attachment(
-                arch, "SRS_to_WPP_route_instructions.pdf", "approved_route"
+                arch, AttachmentDescription("truck_departure.jpg", "arc_primary_image")
+            ),
+            upload_attachment(
+                arch,
+                AttachmentDescription(
+                    "SRS_to_WPP_route_instructions.pdf", "approved_route"
+                ),
             ),
         ],
     )
@@ -206,7 +244,10 @@ def run(arch, args):
                 "wipp_sensors_rad": "45",
             },
             attachments=[
-                upload_attachment(arch, "truck_departure.jpg", "arc_primary_image")
+                upload_attachment(
+                    arch,
+                    AttachmentDescription("truck_departure.jpg", "arc_primary_image"),
+                )
             ],
         )
     LOGGER.info("Waypoints registered...")
@@ -218,14 +259,22 @@ def run(arch, args):
             "description": "At WIPP, inventory"
             + cask.asset["attributes"]["arc_display_name"],
         },
-        attachments=[upload_attachment(arch, "truck_arrival.jpg", "arc_primary_image")],
+        attachments=[
+            upload_attachment(
+                arch, AttachmentDescription("truck_arrival.jpg", "arc_primary_image")
+            )
+        ],
     )
     cask.arrival(
         {
             "description": cask.asset["attributes"]["arc_display_name"]
             + "arriving at WIPP",
         },
-        attachments=[upload_attachment(arch, "truck_arrival.jpg", "arc_primary_image")],
+        attachments=[
+            upload_attachment(
+                arch, AttachmentDescription("truck_arrival.jpg", "arc_primary_image")
+            )
+        ],
     )
     LOGGER.info("Arrival registered...")
 
@@ -240,7 +289,10 @@ def run(arch, args):
             "wipp_container": "",
         },
         attachments=[
-            upload_attachment(arch, "trupact_unloading.jpg", "arc_primary_image")
+            upload_attachment(
+                arch,
+                AttachmentDescription("trupact_unloading.jpg", "arc_primary_image"),
+            )
         ],
     )
     cask.unloading(
@@ -251,7 +303,10 @@ def run(arch, args):
             "wipp_inventory": "",
         },
         attachments=[
-            upload_attachment(arch, "trupact_unloading.jpg", "arc_primary_image")
+            upload_attachment(
+                arch,
+                AttachmentDescription("trupact_unloading.jpg", "arc_primary_image"),
+            )
         ],
     )
     LOGGER.info("Unloading registered...")
@@ -264,7 +319,9 @@ def run(arch, args):
             "location": "D-32",
         },
         attachments=[
-            upload_attachment(arch, "waste_placement.jpg", "arc_primary_image")
+            upload_attachment(
+                arch, AttachmentDescription("waste_placement.jpg", "arc_primary_image")
+            )
         ],
     )
     LOGGER.info("Emplacement registered...")

--- a/archivist_samples/wipp/wipp.py
+++ b/archivist_samples/wipp/wipp.py
@@ -14,19 +14,20 @@ from typing import Optional
 
 from archivist import archivist as type_helper
 
-from ..testing.assets import make_assets_create
+from ..testing.assets import make_assets_create, AttachmentDescription
 
 from . import wipp_files
 
 LOGGER = logging.getLogger(__name__)
 
 
-def upload_attachment(arch, path, name):
-    with resources.open_binary(wipp_files, path) as fd:
+def upload_attachment(arch, attachment_description: AttachmentDescription):
+    with resources.open_binary(wipp_files, attachment_description.filename) as fd:
         blob = arch.attachments.upload(fd)
         attachment = {
-            "arc_display_name": name,
-            "arc_file_name": path,
+            # sample-specific attr to relay attachment name
+            "rkvst_samples_display_name": attachment_description.attribute_name,
+            "arc_file_name": attachment_description.filename,
             "arc_attribute_type": "arc_attachment",
             "arc_blob_identity": blob["identity"],
             "arc_blob_hash_alg": blob["hash"]["alg"],
@@ -35,16 +36,16 @@ def upload_attachment(arch, path, name):
         return attachment
 
 
-def attachment_create(arch, name):
-    with resources.open_binary(wipp_files, name[0]) as fd:
+def attachment_create(arch, attachment_description: AttachmentDescription):
+    with resources.open_binary(wipp_files, attachment_description.filename) as fd:
         attachment = arch.attachments.upload(fd)
         result = {
             "arc_attribute_type": "arc_attachment",
             "arc_blob_identity": attachment["identity"],
             "arc_blob_hash_alg": attachment["hash"]["alg"],
             "arc_blob_hash_value": attachment["hash"]["value"],
-            "arc_display_name": name[1],
-            "arc_file_name": name[0],
+            "arc_display_name": attachment_description.attribute_name,
+            "arc_file_name": attachment_description.filename,
         }
 
         return result
@@ -149,8 +150,8 @@ class Wipp:
             "arc_evidence": "N/A",
         }
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -192,8 +193,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -235,8 +236,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -274,8 +275,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -306,8 +307,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -340,8 +341,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -372,8 +373,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -405,8 +406,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)
@@ -444,8 +445,8 @@ class Wipp:
         }
 
         safe_attachments = attachments or []
-        for i, attachment in enumerate(safe_attachments):
-            attrs[f"attachment_attr_{i}"] = attachment
+        for attachment in safe_attachments:
+            attrs[attachment["rkvst_samples_display_name"]] = attachment
 
         if custom_attrs is not None:
             attrs.update(custom_attrs)


### PR DESCRIPTION
Attachment attribute naming needs fixing to correctly use arc_primary_images for the WIPP samples. More descriptive names should also be used for other attachment attributes where possible (this is a regression introduced by the recent switch to new style attachments.)

This PR:
- Fixes attribute naming and primary images for WIPP to resolve issue #56 
- Fixes naming of attributes in other samples
- Introduces a standard type for describing attachments

Does not make significant improvements to the software_deployment sample as its not used / deprecated