### PR TITLE
Dependabot alert for cryptography v38

### DIFF
--- a/archivist_samples/signed_records/main.py
+++ b/archivist_samples/signed_records/main.py
@@ -63,7 +63,7 @@ def load_keys(asset_name):
         privkey_pem = privkeyfile.read().strip()
 
     backend = backends.default_backend()
-    private_key = backend.load_pem_private_key(privkey_pem, password=None)
+    private_key = backend.load_pem_private_key(privkey_pem, None, False)
     public_key = private_key.public_key()
 
     return private_key, public_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-# TODO: this version is subject to a security alert but
-# upgrading requires code changes.
-cryptography~=38.0
+cryptography~=41.0.0
 rkvst-archivist==0.22.0
 pyyaml~=6.0


### PR DESCRIPTION
Problem:
cryptography dependency has security vulnerabilities CVE-2023-0286 High severity
CVE-2023-23931 Moderate severity

Solution:
Upgrade cryptography to v41.0.

Fixes [AB#7856](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/7856)

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>