### PR TITLE
Reducing charger sample to a month instead of a year -- way too long

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ archivist_samples_signed_records $ARGS --check 'samples'
 
 ```bash
 archivist_samples_synsation initialise  $ARGS --num-assets 100 --wait 1 --await-confirmation
-archivist_samples_synsation charger     $ARGS --start-date 20190909 --stop-date 20200909 --fast-forward 9876
+archivist_samples_synsation charger     $ARGS --start-date 20190909 --stop-date 20191009 --fast-forward 9876
 archivist_samples_synsation simulator   $ARGS --asset-name tcl.ccj.001 --wait 1.0
 archivist_samples_synsation wanderer    $ARGS
 archivist_samples_synsation analyze     $ARGS 


### PR DESCRIPTION
Reduced the date range for charger sample from a year to a month
Sample runs too long -- bearer token times out 
Reducing sample to  fit in a 10-15 minute time frame. . . the time one may take a break from work is more reasonable
Un-delightful to sit and wait until sample times out  . . . most will walk away or ctrl-c