### PR TITLE
Use portable temporary directory

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,14 +6,13 @@ name: Python Quality Control
 on: [pull_request]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  build_matrix:
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11" ]
-
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -25,6 +24,7 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install -r requirements-dev.txt
         python3 -m pip install wheel
+      shell: bash
     - name: Run integrity checks
       run: |
         export PYTHONPATH=samples:${PYTHONPATH}
@@ -37,3 +37,4 @@ jobs:
             echo "there are $modified files that must be reformatted"
             exit 1
         fi
+      shell: bash

--- a/archivist_samples/door_entry/run.py
+++ b/archivist_samples/door_entry/run.py
@@ -7,6 +7,7 @@ from importlib import resources
 
 from copy import copy
 import logging
+from tempfile import TemporaryFile
 from sys import exit as sys_exit
 import uuid
 
@@ -325,7 +326,7 @@ def list_doors(doors):
         for a in attachments:
             print(f"\tAttachment identity: \t{a['arc_blob_identity']}")
             print(f"\tAttachment name: \t{a.get('arc_display_name')}")
-            with open("/tmp/xxx", "wb") as fd:
+            with TemporaryFile(mode="wb") as fd:
                 doors.attachments.download(a["arc_blob_identity"], fd)
 
         print("-----")


### PR DESCRIPTION
Problem:
Code used Linux specific tenporary directory.

Solution:
Use tempfile module for OS-agnostic temporary directory.

Test on Windows in Pipeline.
