### PR TITLE
Ensure run() handles exiting and unreachable code removed

### DIFF
--- a/archivist_samples/c2pa/main.py
+++ b/archivist_samples/c2pa/main.py
@@ -3,8 +3,6 @@
 # pylint:  disable=missing-docstring
 
 import logging
-from sys import exit as sys_exit
-from sys import stdout as sys_stdout
 
 from ..testing.archivist_parser import common_parser
 from ..testing.parser import common_endpoint
@@ -30,6 +28,3 @@ def main():
     poc = common_endpoint("document", args)
 
     run(poc, args)
-
-    parser.print_help(sys_stdout)
-    sys_exit(1)

--- a/archivist_samples/c2pa/run.py
+++ b/archivist_samples/c2pa/run.py
@@ -179,3 +179,4 @@ def run(arch, args):
         },
     )
     LOGGER.info("V1.3.ME published")
+    sys_exit(0)

--- a/archivist_samples/document/main.py
+++ b/archivist_samples/document/main.py
@@ -3,8 +3,6 @@
 # pylint:  disable=missing-docstring
 
 import logging
-from sys import exit as sys_exit
-from sys import stdout as sys_stdout
 
 from ..testing.archivist_parser import common_parser
 from ..testing.parser import common_endpoint
@@ -30,6 +28,3 @@ def main():
     poc = common_endpoint("document", args)
 
     run(poc, args)
-
-    parser.print_help(sys_stdout)
-    sys_exit(1)

--- a/archivist_samples/sbom_document/main.py
+++ b/archivist_samples/sbom_document/main.py
@@ -3,8 +3,6 @@
 # pylint:  disable=missing-docstring
 
 import logging
-from sys import exit as sys_exit
-from sys import stdout as sys_stdout
 
 from ..testing.archivist_parser import common_parser
 from ..testing.parser import common_endpoint
@@ -32,6 +30,3 @@ def main():
     arch = common_endpoint("sbom", args)
 
     run(arch, args)
-
-    parser.print_help(sys_stdout)
-    sys_exit(1)

--- a/archivist_samples/wipp/main.py
+++ b/archivist_samples/wipp/main.py
@@ -3,8 +3,6 @@
 # pylint:  disable=missing-docstring
 
 import logging
-from sys import exit as sys_exit
-from sys import stdout as sys_stdout
 
 from ..testing.archivist_parser import common_parser
 from ..testing.parser import common_endpoint
@@ -30,6 +28,3 @@ def main():
     poc = common_endpoint("wipp", args)
 
     run(poc, args)
-
-    parser.print_help(sys_stdout)
-    sys_exit(1)


### PR DESCRIPTION
[AB#8310](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/8310)

## Testing

```
$> archivist_samples_document -p SIMPLE_HASH -u https://app.dev-jgough-0.dev.jitsuin.io -t credentials/authtoken 
Initialising connection to RKVST...
Using version v0.25.0 of rkvst-archivist
Fetching use case test assets namespace document
Creating Document Asset ...
Asteroid Mining Inc Invoice does not exist
Invoice Asset Created (Identity=assets/0189d204-5b5a-4d4f-9461-2e4085434e41)
Publishing V2 ...
V2 published, with order number
Publishing V3 ...
V3 published, with discount applied
$> echo $?
0
```

Help still works:
```
$ archivist_samples_document --help
usage: archivist_samples_document [-h] [-v] [-u URL] [-p {KHIPU,SIMPLE_HASH}] -t AUTH_TOKEN_FILE [--namespace NAMESPACE]

Document Sample

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         print verbose debugging
  -u URL, --url URL     url of Archivist service
  -p {KHIPU,SIMPLE_HASH}, --proof-mechanism {KHIPU,SIMPLE_HASH}
                        mechanism for proving the evidence for events on the Asset
  -t AUTH_TOKEN_FILE, --auth-token AUTH_TOKEN_FILE
                        FILE containing API authentication token
  --namespace NAMESPACE
                        namespace of item population (to enable parallel demos)
```
<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>