### PR TITLE
Upgrade to rkvst-archivist 0.25.2

### DIFF
--- a/archivist_samples/sbom_document/README.md
+++ b/archivist_samples/sbom_document/README.md
@@ -142,7 +142,7 @@ In order to control data sharing to restrict general customers to see only the r
       "access_permissions": [
         {
           "subjects": [ "subjects/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" ],
-          "behaviours": [ "Attachments", "RecordEvidence" ],
+          "behaviours": [ "RecordEvidence" ],
           "include_attributes": [],
           "user_attributes": [],
           "asset_attributes_read": [

--- a/archivist_samples/software_bill_of_materials/README.md
+++ b/archivist_samples/software_bill_of_materials/README.md
@@ -150,7 +150,7 @@ In order to control data sharing to restrict general customers to see only the r
       "access_permissions": [
         {
           "subjects": [ "subjects/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" ],
-          "behaviours": [ "Attachments", "RecordEvidence" ],
+          "behaviours": [ "RecordEvidence" ],
           "include_attributes": [],
           "user_attributes": [],
           "asset_attributes_read": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography~=41.0.2
-rkvst-archivist==0.25.0
+rkvst-archivist==0.25.2
 pyyaml~=6.0.1


### PR DESCRIPTION
To eliminate use of obsolete Attachments behaviour

[AB#4810](https://dev.azure.com/jitsuin/0629f48c-3979-4bbc-9026-cb06b3dfd0ae/_workitems/edit/4810)
