### PR TITLE
Add c2pa to the taskfile

### DIFF
--- a/scripts/samples.sh
+++ b/scripts/samples.sh
@@ -24,6 +24,7 @@ if [ -z "${TEST_SELECTOR}" -o "$TEST_SELECTOR" = 'help' ]
 then
     echo "Available functional tests are:"
     echo ""
+    echo "    TEST_SELECTOR=c2pa ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=door_entry ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=estate_info ${SAMPLESCMD}"
     echo "    TEST_SELECTOR=signed_records ${SAMPLESCMD}"
@@ -61,6 +62,7 @@ then
     TEST_NO=''
 fi
 
+TEST_NO_C2PA=${TEST_NO}
 TEST_NO_DOOR_ENTRY=${TEST_NO}
 TEST_NO_ESTATE_INFO=${TEST_NO}
 TEST_NO_SIGNED_RECORDS=${TEST_NO}
@@ -107,6 +109,10 @@ command() {
         echo "archivist_samples_$1"
     fi
 }
+
+# archivist_samples_c2pa
+C2PA="${TEST_NO_C2PA} $(command c2pa) ${ARGS} ${NAMESPACE}"
+${C2PA}
 
 # archivist_samples_door_entry
 DOOR_ENTRY="${TEST_NO_DOOR_ENTRY} $(command door_entry) ${ARGS} ${NAMESPACE}"


### PR DESCRIPTION
## Overview
* Add c2pa sample to taskfile

## Testing
Help text:
```
$ TEST_SELECTOR=help task samples
task: Task "about" is up to date
task: [samples] ./scripts/api.sh ./scripts/samples.sh
Available functional tests are:

    TEST_SELECTOR=c2pa task samples
    TEST_SELECTOR=door_entry task samples
    TEST_SELECTOR=estate_info task samples
    TEST_SELECTOR=signed_records task samples
    TEST_SELECTOR=synsation_initialise task samples
    TEST_SELECTOR=synsation_charger task samples
    TEST_SELECTOR=synsation_simulator task samples
    TEST_SELECTOR=synsation_wanderer task samples
    TEST_SELECTOR=synsation_analyze task samples
    TEST_SELECTOR=sbom task samples
    TEST_SELECTOR=wipp task samples
    TEST_SELECTOR=document task samples

To run more than one test use a comma-separated list:

    TEST_SELECTOR=door_entry,estate_info task samples

To run all tests:

    TEST_SELECTOR=all task samples

Additionally:

    TEST_NAMESPACE=
    TEST_VERBOSE=
```
example execution:
```
$ TEST_SELECTOR=c2pa task samples
task: Task "about" is up to date
task: [samples] ./scripts/api.sh ./scripts/samples.sh
No NAMESPACE specified - may share assets etc with someone else on same URL
Initialising connection to RKVST...
Using version v0.23.0 of rkvst-archivist
Fetching use case test assets namespace document
Creating C2PA Asset ...
Adobe C2PA Image already existed
C2PA Document C2PA Image already exists (Identity=assets/2a17ed5f-5145-4477-8a0f-45f4d438cc49)
```

AB#8311