### PR TITLE
Support python 3.12

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11" ]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12" ]
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,6 +29,11 @@ tasks:
     cmds:
       - docker build --no-cache --build-arg VERSION=3.11 -f Dockerfile -t rkvst-samples-api .
 
+  api-3.12:
+    desc: Build a docker environment with the right dependencies and utilities
+    cmds:
+      - docker build --no-cache --build-arg VERSION=3.12 -f Dockerfile -t rkvst-samples-api .
+
   check:
     desc: Check the style, bug and quality of the code
     deps: [about]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,10 @@
 
 # code quality
 autopep8~=2.0
-black~=23.7
+black~=23.9
 pycodestyle~=2.10
-pylint~=2.17
+pylint~=3.0
 
 # uploading to pypi
-build~=0.10
+build~=1.0
 twine~=4.0


### PR DESCRIPTION
Add support for python 3.12
Upgrade pylint to 3.0 and other tools.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>