### PR TITLE
Removing proof mechanism environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,9 @@ export TEST_ARCHIVIST="https://app.rkvst.io"
 export TEST_AUTHTOKEN_FILENAME=credentials/.auth_token
 export TEST_NAMESPACE="unique label"
 export TEST_VERBOSE=-v
-export TEST_PROOF_MECHANISM="--proof-mechanism=SIMPLE_HASH"
 ```
 
 If TEST_VERBOSE is "-v" debugging output will appear when running the examples. Otherwise leave blank or undefined.
-
-TEST_PROOF_MECHANISM should be "KHIPU" or "SIMPLE_HASH". If unspecified the default is "SIMPLE_HASH"
 
 Windows using Powershell - at the command prompt set values for environment variables:
 
@@ -48,7 +45,6 @@ $Env:TEST_ARCHIVIST="https://app.rkvst.io"
 $Env:TEST_AUTHTOKEN_FILENAME = '<path of token location>'
 $Env:TEST_NAMESPACE = Get-Date -UFormat %s
 $Env:TEST_VERBOSE = '-v'
-$Env:TEST_PROOF_MECHANISM="--proof-mechanism=SIMPLE_HASH"
 ```
 
 TEST_NAMESPACE is set to the date and time value in Unix format, thus providing a unique id upon execution.
@@ -73,7 +69,7 @@ Events are created every execution of an example - currently no check is done if
 All examples use a common set of arguments:
 
 ```bash
-export AUTH="-u $TEST_ARCHIVIST -t $TEST_AUTHTOKEN_FILENAME $TEST_VERBOSE $TEST_PROOF_MECHANISM"
+export AUTH="-u $TEST_ARCHIVIST -t $TEST_AUTHTOKEN_FILENAME $TEST_VERBOSE"
 export ARGS="$AUTH --namespace $TEST_NAMESPACE"
 ```
 


### PR DESCRIPTION
Yes, am aware that proof mechanism is valid and we have removed KHIPU.

Based on recent changes and talks, makes sense to remove the proof mechanism environment variable on the readme for samples since KHIPU is not an option and we are leaning towards most users on simple hash.  Greater number of people using our samples "should" be on simple hash in theory.  Removing decreases confusion and ran wipp sample w/out the environment variable and as expected it works.

Oh and removed the word "KHIPU" from the main repo readme also.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>